### PR TITLE
Fixes ImportError in Python3

### DIFF
--- a/searcheval/helpers.py
+++ b/searcheval/helpers.py
@@ -4,7 +4,7 @@ from __future__ import division
 try:
     from itertools import izip as zip
     range = xrange
-except NameError:
+except (NameError, ImportError):
     pass
 
 

--- a/searcheval/metrics.py
+++ b/searcheval/metrics.py
@@ -6,7 +6,7 @@ from searcheval.helpers import cumsum, divide
 try:
     from itertools import izip as zip
     range = xrange
-except NameError:
+except (NameError, ImportError):
     pass
 
 


### PR DESCRIPTION
This PR fixes the [ImportError issue](https://github.com/tobigue/searcheval/issues/1) in Python3.